### PR TITLE
Fix Github Workflows 

### DIFF
--- a/.github/workflows/brakeman.yml
+++ b/.github/workflows/brakeman.yml
@@ -1,7 +1,7 @@
 name: Gnar Brakeman
 on:
   push:
-    branches: [$default-branch]
+    branches: ["main"]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/bundler-audit.yml
+++ b/.github/workflows/bundler-audit.yml
@@ -1,7 +1,7 @@
 name: Gnar Bundler Audit
 on:
   push:
-    branches: [$default-branch]
+    branches: ["main"]
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/rails-rspec.yml
+++ b/.github/workflows/rails-rspec.yml
@@ -1,7 +1,7 @@
 name: Gnar Rails Rspec
 on:
   push:
-    branches: [$default-branch]
+    branches: ["main"]
 jobs:
   run-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I, Alex Jarvis, very stupidly copied these from our `.github` repo rather than adding them via the github UI. This meant that the templating was ignored, and rather than replace `$default-branch` with `main` as the UI would, we were just running `$default-branch`, which is: nothing. 