### PR TITLE
Create Asset model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ end
 group :test do
   gem "capybara"
   gem "selenium-webdriver"
+  gem 'webdrivers', '~> 4.1', '>= 4.1.3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.7.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (> 3.141, < 5.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -407,6 +411,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers (~> 4.1, >= 4.1.3)
 
 RUBY VERSION
    ruby 3.1.0p0

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -2,16 +2,15 @@ class Asset < ApplicationRecord
   belongs_to :user
 
   enum asset_type: {
-    laptop: 0,
-    display: 1,
-    keyboard: 2,
-    mouse: 3,
-    power_supply: 4,
-    desk: 5,
-    chair: 6,
+    laptop: "laptop",
+    display: "display",
+    keyboard: "keyboard",
+    mouse: "mouse",
+    power_supply: "power supply",
+    desk: "desk",
+    chair: "chair",
   }
 
-  validates :user_id, presence: true
   validates :model_number, presence: true
   validates :serial_number, presence: true
   validates :approximate_purchase_date, presence: true

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -9,7 +9,6 @@ class Asset < ApplicationRecord
     power_supply: 4,
     desk: 5,
     chair: 6,
-    other: 7,
   }
 
   validates :user_id, presence: true

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,0 +1,20 @@
+class Asset < ApplicationRecord
+  belongs_to :user
+
+  enum asset_type: {
+    laptop: 0,
+    display: 1,
+    keyboard: 2,
+    mouse: 3,
+    power_supply: 4,
+    desk: 5,
+    chair: 6,
+    other: 7,
+  }
+
+  validates :user_id, presence: true
+  validates :model_number, presence: true
+  validates :serial_number, presence: true
+  validates :approximate_purchase_date, presence: true
+  validates :phone_number, presence: true
+end

--- a/db/migrate/20220721201913_create_assets.rb
+++ b/db/migrate/20220721201913_create_assets.rb
@@ -1,0 +1,16 @@
+class CreateAssets < ActiveRecord::Migration[7.0]
+  def change
+    create_table :assets do |t|
+      t.date :approximate_purchase_date, null: false
+      t.integer :asset_type, null: false, default: 0
+      t.text :description
+      t.string :mac_address
+      t.string :model_number, null: false
+      t.string :phone_number, null: false
+      t.string :serial_number, null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220721201913_create_assets.rb
+++ b/db/migrate/20220721201913_create_assets.rb
@@ -3,7 +3,6 @@ class CreateAssets < ActiveRecord::Migration[7.0]
     create_table :assets do |t|
       t.date :approximate_purchase_date, null: false
       t.integer :asset_type, null: false, default: 0
-      t.text :description
       t.string :mac_address
       t.string :model_number, null: false
       t.string :phone_number, null: false

--- a/db/migrate/20220721201913_create_assets.rb
+++ b/db/migrate/20220721201913_create_assets.rb
@@ -2,12 +2,12 @@ class CreateAssets < ActiveRecord::Migration[7.0]
   def change
     create_table :assets do |t|
       t.date :approximate_purchase_date, null: false
-      t.integer :asset_type, null: false, default: 0
+      t.string :asset_type, null: false, default: "laptop"
       t.string :mac_address
       t.string :model_number, null: false
       t.string :phone_number, null: false
       t.string :serial_number, null: false
-      t.references :user, foreign_key: true
+      t.references :user, foreign_key: true, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,12 +24,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_201913) do
 
   create_table "assets", force: :cascade do |t|
     t.date "approximate_purchase_date", null: false
-    t.integer "asset_type", default: 0, null: false
+    t.string "asset_type", default: "laptop", null: false
     t.string "mac_address"
     t.string "model_number", null: false
     t.string "phone_number", null: false
     t.string "serial_number", null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_assets_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_11_132945) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_21_201913) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,20 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_11_132945) do
     t.index ["name"], name: "index_asset_types_on_name", unique: true
   end
 
+  create_table "assets", force: :cascade do |t|
+    t.date "approximate_purchase_date", null: false
+    t.integer "asset_type", default: 0, null: false
+    t.text "description"
+    t.string "mac_address"
+    t.string "model_number", null: false
+    t.string "phone_number", null: false
+    t.string "serial_number", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_assets_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.datetime "created_at", null: false
@@ -31,4 +45,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_11_132945) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "assets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,17 +14,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_201913) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "asset_types", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_asset_types_on_name", unique: true
-  end
-
   create_table "assets", force: :cascade do |t|
     t.date "approximate_purchase_date", null: false
-    t.string "asset_type", default: "laptop", null: false
+    t.string "asset_type", default: "unknown", null: false
     t.string "mac_address"
     t.string "model_number", null: false
     t.string "phone_number", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,7 +25,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_201913) do
   create_table "assets", force: :cascade do |t|
     t.date "approximate_purchase_date", null: false
     t.integer "asset_type", default: 0, null: false
-    t.text "description"
     t.string "mac_address"
     t.string "model_number", null: false
     t.string "phone_number", null: false

--- a/spec/factories/assets.rb
+++ b/spec/factories/assets.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :asset do
-    approximate_purchase_date { "2022-07-21" }
+    approximate_purchase_date { Date.new(2022, 7, 21) }
     asset_type { "laptop" }
     mac_address { "00:25:96:FF:FE:12:34:56" }
     model_number { "89734696" }

--- a/spec/factories/assets.rb
+++ b/spec/factories/assets.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :asset do
     approximate_purchase_date { "2022-07-21" }
     asset_type { "laptop" }
-    description { "MyTextDescription" }
     mac_address { "00:25:96:FF:FE:12:34:56" }
     model_number { "89734696" }
     phone_number { "555-555-5555" }

--- a/spec/factories/assets.rb
+++ b/spec/factories/assets.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :asset do
+    approximate_purchase_date { "2022-07-21" }
+    asset_type { "laptop" }
+    description { "MyTextDescription" }
+    mac_address { "00:25:96:FF:FE:12:34:56" }
+    model_number { "89734696" }
+    phone_number { "555-555-5555" }
+    serial_number { "453h459-kj4h5-7835ae" }
+    user
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Asset, type: :model do
   end
 
   describe "validations" do
-    it { should validate_presence_of(:user_id) }
     it { should validate_presence_of(:model_number) }
     it { should validate_presence_of(:serial_number) }
     it { should validate_presence_of(:approximate_purchase_date) }
@@ -16,14 +15,14 @@ RSpec.describe Asset, type: :model do
   describe "enums" do
     it {
       should define_enum_for(:asset_type).with_values({
-        laptop: 0,
-        display: 1,
-        keyboard: 2,
-        mouse: 3,
-        power_supply: 4,
-        desk: 5,
-        chair: 6,
-      })
+        laptop: "laptop",
+        display: "display",
+        keyboard: "keyboard",
+        mouse: "mouse",
+        power_supply: "power supply",
+        desk: "desk",
+        chair: "chair",
+      }).backed_by_column_of_type(:string)
     }
   end
 end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Asset, type: :model do
+  describe "associations" do
+    it { should belong_to(:user) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:user_id) }
+    it { should validate_presence_of(:model_number) }
+    it { should validate_presence_of(:serial_number) }
+    it { should validate_presence_of(:approximate_purchase_date) }
+    it { should validate_presence_of(:phone_number) }
+  end
+
+  describe "enums" do
+    it {
+      should define_enum_for(:asset_type).with_values({
+        laptop: 0,
+        display: 1,
+        keyboard: 2,
+        mouse: 3,
+        power_supply: 4,
+        desk: 5,
+        chair: 6,
+        other: 7,
+      })
+    }
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Asset, type: :model do
         power_supply: 4,
         desk: 5,
         chair: 6,
-        other: 7,
       })
     }
   end


### PR DESCRIPTION
This PR:

- adds new `Asset` model
- associates Assets with Users
- creates an `asset_type` enum

```mermaid
erDiagram
  User ||--|{ Asset : has_many
  User {
  }
  Asset {
    id ID
    id user_id
    datetime created_at
    datetime updated_at
    string model_number
    string serial_number
    date approximate_purchase_date
    string mac_address
    string phone_number
    integer asset_type
  }
```

---

### Notes

- **MAC Address is optional** 
- ~**The optional description field**~
  - ~The thought being that this would be "nice to have" in the event that an asset is of an "other" type. Does this make sense?~
- **The `asset_type` enum**
  - What should go in this list?
 