### PR TITLE
Create asset form

### DIFF
--- a/app/assets/stylesheets/_models.scss
+++ b/app/assets/stylesheets/_models.scss
@@ -1,16 +1,17 @@
-.users-layout {
+.main-layout {
   display: flex;
 }
 
-.button.add-gnarnian {
+.button.add {
   margin: 0 15px;
 }
 
-.button.create-user {
+.button.create {
   margin: 0;
 }
 
-#new_user_form {
+#new_user_form,
+#new_gnar_asset_form {
   margin: 0 15px;
 
   label {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,5 +5,5 @@
 @import "forms";
 @import "header";
 @import "main";
-@import "users";
+@import "models";
 @import "session";

--- a/app/controllers/gnar/assets_controller.rb
+++ b/app/controllers/gnar/assets_controller.rb
@@ -1,6 +1,42 @@
 module Gnar
   class AssetsController < AuthenticatedController
+    before_action :set_assets, only: [:index, :create]
+
     def index
+    end
+
+    def new
+      @asset = Asset.new
+    end
+
+    def create
+      @asset = Asset.new(asset_params)
+
+      respond_to do |format|
+        if @asset.save
+          format.turbo_stream
+
+          format.html { redirect_to gnar_asset_path(@asset), notice: "Asset created!" }
+        else
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.replace("#{helpers.dom_id(@asset)}_form",
+              partial: "new_form",
+              locals: { asset: @asset })
+          end
+
+          format.html { render :new, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    private
+
+    def asset_params
+      params.permit(:user_id, :asset_type, :approximate_purchase_date, :model_number, :serial_number,
+        :mac_address, :phone_number, :serial_number)
+    end
+
+    def set_assets
       @assets = Asset.all.includes(:user)
     end
   end

--- a/app/controllers/gnar/assets_controller.rb
+++ b/app/controllers/gnar/assets_controller.rb
@@ -32,8 +32,8 @@ module Gnar
     private
 
     def asset_params
-      params.permit(:user_id, :asset_type, :approximate_purchase_date, :model_number, :serial_number,
-        :mac_address, :phone_number, :serial_number)
+      params.permit(:user_id, :asset_type, :approximate_purchase_date, :model_number,
+        :serial_number, :mac_address, :phone_number, :serial_number)
     end
 
     def set_assets

--- a/app/views/gnar/assets/_asset.html.erb
+++ b/app/views/gnar/assets/_asset.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr class="asset">
   <td>
     <%= asset.asset_type %>
   </td>

--- a/app/views/gnar/assets/_new_form.html.erb
+++ b/app/views/gnar/assets/_new_form.html.erb
@@ -38,6 +38,6 @@
       <%= form.label :serial_number %>
       <%= form.text_field :serial_number %>
     </div>
-    <%= form.submit "Create Asset", class: "button special create" %>
+    <%= form.submit "Send it!", class: "button special create" %>
   <% end %>
 </div>

--- a/app/views/gnar/assets/_new_form.html.erb
+++ b/app/views/gnar/assets/_new_form.html.erb
@@ -1,0 +1,43 @@
+<div>
+  <%= form_with(url: gnar_assets_path, id: "#{dom_id(asset)}_form") do |form| %>
+    <h2 class="title">Add an Asset</h2>
+    <% if asset.errors.any? %>
+      <div class="errors">
+        <ul>
+          <% asset.errors.each do |e| %>
+            <li class="error-msg"><%= e.full_message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <div class="form-element">
+      <%= form.label :user_id, "User" %>
+      <%= form.select :user_id, User.all.map { |u| [u.email, u.id]}, include_blank: true %>
+    </div>
+    <div class="form-element">
+      <%= form.label :asset_type %>
+      <%= form.select :asset_type, Gnar::Asset.asset_types, include_blank: true %>
+    </div>
+    <div class="form-element">
+      <%= form.label :approximate_purchase_date %>
+      <%= form.date_field :approximate_purchase_date %>
+    </div>
+    <div class="form-element">
+      <%= form.label :mac_address %>
+      <%= form.text_field :mac_address %>
+    </div>
+    <div class="form-element">
+      <%= form.label :model_number %>
+      <%= form.text_field :model_number %>
+    </div>
+    <div class="form-element">
+      <%= form.label :phone_number %>
+      <%= form.text_field :phone_number %>
+    </div>
+    <div class="form-element">
+      <%= form.label :serial_number %>
+      <%= form.text_field :serial_number %>
+    </div>
+    <%= form.submit "Create Asset", class: "button special create" %>
+  <% end %>
+</div>

--- a/app/views/gnar/assets/_table.html.erb
+++ b/app/views/gnar/assets/_table.html.erb
@@ -1,22 +1,24 @@
-<table>
-  <thead>
-    <th scope="col">
-      Type
-    </th>
-    <th scope="col">
-      Gnarnian
-    </th>
-    <th scope="col">
-      Model Number
-    </th>
-    <th scope="col">
-      Serial Number
-    </th>
-    <th scope="col">
-      Date of Purchase (approx)
-    </th>
-  </thead>
-  <tbody>
-    <%= render assets %>
-  </tbody>
-</table>
+<%= turbo_frame_tag "gnar-assets" do %>
+  <table>
+    <thead>
+      <th scope="col">
+        Type
+      </th>
+      <th scope="col">
+        Gnarnian
+      </th>
+      <th scope="col">
+        Model Number
+      </th>
+      <th scope="col">
+        Serial Number
+      </th>
+      <th scope="col">
+        Date of Purchase (approx)
+      </th>
+    </thead>
+    <tbody>
+      <%= render assets %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/gnar/assets/create.turbo_stream.erb
+++ b/app/views/gnar/assets/create.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.replace "gnar-assets" do %>
+  <%= render "gnar/assets/table", assets: @assets %>
+<% end %>
+<%= turbo_stream.replace "#{dom_id(Gnar::Asset.new)}_form" do %>
+  <%= render "new_form", asset: Gnar::Asset.new %>
+<% end %>

--- a/app/views/gnar/assets/index.html.erb
+++ b/app/views/gnar/assets/index.html.erb
@@ -1,7 +1,13 @@
 <% content_for :title do %>
   Assets
 <% end %>
-
-<div>
-  <%= render "gnar/assets/table", assets: @assets %>
+<div class="main-layout">
+  <div>
+    <div>
+      <%= render "gnar/assets/table", assets: @assets %>
+    </div>
+  </div>
+  <%= turbo_frame_tag "new_asset_frame" do %>
+    <%= link_to "Add an Asset", new_gnar_asset_path, class: "button standard add" %>
+  <% end %>
 </div>

--- a/app/views/gnar/assets/new.html.erb
+++ b/app/views/gnar/assets/new.html.erb
@@ -1,0 +1,4 @@
+<%= link_to "Back to Assets", gnar_assets_path %>
+<%= turbo_frame_tag "new_asset_frame" do %>
+  <%= render "new_form", asset: @asset %>
+<% end %>

--- a/app/views/gnar/users/_new_form.html.erb
+++ b/app/views/gnar/users/_new_form.html.erb
@@ -22,6 +22,6 @@
       <%= form.label :email %>
       <%= form.text_field :email %>
     </div>
-    <%= form.submit "Create Life!", class: "button special create" %>
+    <%= form.submit "Send it!", class: "button special create" %>
   <% end %>
 </div>

--- a/app/views/gnar/users/_new_form.html.erb
+++ b/app/views/gnar/users/_new_form.html.erb
@@ -1,7 +1,6 @@
 <div>
   <%= form_with(url: gnar_users_path, id: "#{dom_id(user)}_form") do |form| %>
     <h2 class="title">Add a Gnarnian</h2>
-
     <% if user.errors.any? %>
       <div class="errors">
         <ul>
@@ -11,25 +10,18 @@
         </ul>
       </div>
     <% end %>
-
     <div class="form-element">
       <%= form.label :first_name %>
-
       <%= form.text_field :first_name %>
     </div>
-
     <div class="form-element">
       <%= form.label :last_name %>
-
       <%= form.text_field :last_name %>
     </div>
-
     <div class="form-element">
       <%= form.label :email %>
-
       <%= form.text_field :email %>
     </div>
-
-    <%= form.submit "Send It!", class: "button special create-user" %>
+    <%= form.submit "Create Life!", class: "button special create" %>
   <% end %>
 </div>

--- a/app/views/gnar/users/_user.html.erb
+++ b/app/views/gnar/users/_user.html.erb
@@ -2,11 +2,9 @@
   <td>
     <%= user.first_name%>
   </td>
-
   <td>
     <%= user.last_name %>
   </td>
-
   <td>
     <%= user.email %>
   </td>

--- a/app/views/gnar/users/create.turbo_stream.erb
+++ b/app/views/gnar/users/create.turbo_stream.erb
@@ -1,7 +1,6 @@
 <%= turbo_stream.replace "gnar-users" do %>
   <%= render "gnar/users/table", users: @users %>
 <% end %>
-
 <%= turbo_stream.replace "#{dom_id(User.new)}_form" do %>
   <%= render "new_form", user: User.new %>
 <% end %>

--- a/app/views/gnar/users/index.html.erb
+++ b/app/views/gnar/users/index.html.erb
@@ -1,15 +1,13 @@
 <% content_for :title do %>
   Gnarnians
 <% end %>
-
-<div class="users-layout">
+<div class="main-layout">
   <div>
     <div>
       <%= render "gnar/users/table", users: @users %>
     </div>
   </div>
-
   <%= turbo_frame_tag "new_user_frame" do %>
-    <%= link_to "Add a Gnarnian", new_gnar_user_path, class: "button standard add-gnarnian" %>
+    <%= link_to "Add a Gnarnian", new_gnar_user_path, class: "button standard add" %>
   <% end %>
 </div>

--- a/app/views/gnar/users/new.html.erb
+++ b/app/views/gnar/users/new.html.erb
@@ -1,5 +1,4 @@
 <%= link_to "Back to Gnarnians", gnar_users_path %>
-
 <%= turbo_frame_tag "new_user_frame" do %>
   <%= render "new_form", user: @user %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   end
 
   namespace :gnar do
-    resources :assets, only: [:index]
+    resources :assets
     resources :users
   end
 end

--- a/db/migrate/20230626155355_add_null_false_to_asset_type.rb
+++ b/db/migrate/20230626155355_add_null_false_to_asset_type.rb
@@ -1,0 +1,5 @@
+class AddNullFalseToAssetType < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :assets, :asset_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_27_190019) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_155355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_27_190019) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.enum "asset_type", default: "laptop", enum_type: "asset_type_enum"
+    t.enum "asset_type", default: "laptop", null: false, enum_type: "asset_type_enum"
     t.index ["user_id"], name: "index_assets_on_user_id"
   end
 

--- a/spec/system/create_asset_spec.rb
+++ b/spec/system/create_asset_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Creating an Asset", js: true do
+  before { login_as(create(:user, first_name: "Amy")) }
+
+  it "allows a new asset to be created" do
+    visit gnar_assets_path
+
+    click_on "Add an Asset"
+    select "laptop", from: "Asset type"
+    select User.first.email, from: "User"
+    fill_in "Approximate purchase date", with: "2022-07-20"
+    fill_in "Mac address", with: "00001"
+    fill_in "Model number", with: "ABC"
+    fill_in "Serial number", with: "1234"
+
+    click_on "Create Asset"
+
+    expect(page).to have_text "1234"
+  end
+
+  context "if the data is invalid" do
+    it "displays an error message" do
+      visit gnar_assets_path
+
+      click_on "Add an Asset"
+
+      expect { click_on "Create Asset" }.not_to change(Gnar::Asset, :count)
+      expect(page).to have_text("User must exist")
+      expect(page).to have_text("Serial number can't be blank")
+      expect(page).to have_text("Model number can't be blank")
+      expect(page).to have_text("Approximate purchase date can't be blank")
+    end
+  end
+end

--- a/spec/system/create_asset_spec.rb
+++ b/spec/system/create_asset_spec.rb
@@ -14,7 +14,7 @@ describe "Creating an Asset", js: true do
     fill_in "Model number", with: "ABC"
     fill_in "Serial number", with: "1234"
 
-    click_on "Create Asset"
+    click_on "Send it!"
 
     expect(page).to have_text "1234"
   end
@@ -25,7 +25,7 @@ describe "Creating an Asset", js: true do
 
       click_on "Add an Asset"
 
-      expect { click_on "Create Asset" }.not_to change(Gnar::Asset, :count)
+      expect { click_on "Send it!" }.not_to change(Gnar::Asset, :count)
       expect(page).to have_text("User must exist")
       expect(page).to have_text("Serial number can't be blank")
       expect(page).to have_text("Model number can't be blank")

--- a/spec/system/create_user_spec.rb
+++ b/spec/system/create_user_spec.rb
@@ -13,7 +13,7 @@ describe "Creating a user", js: true do
     fill_in "Last name", with: "Enticer"
     fill_in "Email", with: "lenticer@example.com"
 
-    click_on "Create Life!"
+    click_on "Send it!"
 
     expect(page).to have_text "lenticer@example.com"
   end
@@ -25,7 +25,7 @@ describe "Creating a user", js: true do
       click_on "Add a Gnarnian"
       fill_in "Email", with: ""
 
-      expect { click_on "Create Life!" }.not_to change(User, :count)
+      expect { click_on "Send it!" }.not_to change(User, :count)
       expect(page).to have_text("Email can't be blank")
     end
   end

--- a/spec/system/new_asset_spec.rb
+++ b/spec/system/new_asset_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe "Creating a user", js: true do
-  before { login_as(create(:user, first_name: "Amy")) }
+  before { login_as(create(:user, first_name: "Tails")) }
 
-  it "allows a new user to be created" do
+  it "allows a new asset to be created" do
     visit gnar_users_path
 
     expect(page).not_to have_text "lenticer@example.com"

--- a/spec/system/new_asset_spec.rb
+++ b/spec/system/new_asset_spec.rb
@@ -13,7 +13,7 @@ describe "Creating a user", js: true do
     fill_in "Last name", with: "Enticer"
     fill_in "Email", with: "lenticer@example.com"
 
-    click_on "Create Life!"
+    click_on "Send it!"
 
     expect(page).to have_text "lenticer@example.com"
   end
@@ -25,7 +25,7 @@ describe "Creating a user", js: true do
       click_on "Add a Gnarnian"
       fill_in "Email", with: ""
 
-      expect { click_on "Create Life!" }.not_to change(User, :count)
+      expect { click_on "Send it!" }.not_to change(User, :count)
       expect(page).to have_text("Email can't be blank")
     end
   end

--- a/spec/system/view_assets_spec.rb
+++ b/spec/system/view_assets_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Viewing assets" do
+  before do
+    login_as(create(:user, first_name: "Miles", last_name: "Prower", email: "pete-weber@example.com"))
+  end
+
+  it "displays a list of all assets" do
+    asset1 = create(:asset, approximate_purchase_date: Date.new(2022, 7, 20), asset_type: "laptop", mac_address: "10", model_number: "1234", serial_number: "ABC")
+    asset2 = create(:asset, approximate_purchase_date: Date.new(2023, 8, 31), asset_type: "desk", mac_address: "00", model_number: "5678", serial_number: "DEF")
+
+    visit gnar_assets_path
+
+    assets = all(".asset")
+    expect(assets[0]).to have_text asset1.asset_type
+    expect(assets[0]).to have_text asset1.user.email
+    expect(assets[0]).to have_text asset1.model_number
+    expect(assets[0]).to have_text asset1.serial_number
+    expect(assets[0]).to have_text asset1.approximate_purchase_date
+
+    expect(assets[1]).to have_text asset2.asset_type
+    expect(assets[1]).to have_text asset2.user.email
+    expect(assets[1]).to have_text asset2.model_number
+    expect(assets[1]).to have_text asset2.serial_number
+    expect(assets[1]).to have_text asset2.approximate_purchase_date
+  end
+end

--- a/spec/system/view_assets_spec.rb
+++ b/spec/system/view_assets_spec.rb
@@ -2,12 +2,15 @@ require "rails_helper"
 
 describe "Viewing assets" do
   before do
-    login_as(create(:user, first_name: "Miles", last_name: "Prower", email: "pete-weber@example.com"))
+    login_as(create(:user, first_name: "Miles", last_name: "Prower",
+      email: "gottagofast@example.com"))
   end
 
   it "displays a list of all assets" do
-    asset1 = create(:asset, approximate_purchase_date: Date.new(2022, 7, 20), asset_type: "laptop", mac_address: "10", model_number: "1234", serial_number: "ABC")
-    asset2 = create(:asset, approximate_purchase_date: Date.new(2023, 8, 31), asset_type: "desk", mac_address: "00", model_number: "5678", serial_number: "DEF")
+    asset1 = create(:asset, approximate_purchase_date: Date.new(2022, 7, 20), asset_type: "laptop",
+      mac_address: "10", model_number: "1234", serial_number: "ABC")
+    asset2 = create(:asset, approximate_purchase_date: Date.new(2023, 8, 31), asset_type: "desk",
+      mac_address: "00", model_number: "5678", serial_number: "DEF")
 
     visit gnar_assets_path
 


### PR DESCRIPTION
Closes #7

This Pr adds a form that allows users to add Assets to GEAR. 

Styles and UX have been graciously lifted from existing User interfaces. 

Check out this slick gif for more info: 
![gear](https://github.com/TheGnarCo/GEAR/assets/174825/ec3d0f51-fca9-498e-8f12-624d8b440d66)
